### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET env variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import os
+import platform
+import sysconfig
 import subprocess
 import tarfile
 import shutil
@@ -53,6 +55,10 @@ class jq_build_ext(build_ext):
                     configure_args.append('YACC=' + yacc)
             except subprocess.CalledProcessError:
                 print("No Homebrew yacc found")
+
+        macosx_deployment_target = sysconfig.get_config_var("MACOSX_DEPLOYMENT_TARGET")
+        if macosx_deployment_target:
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = macosx_deployment_target
 
         command(["autoreconf", "-i"])
         command(["./configure"] + configure_args)


### PR DESCRIPTION
to prevent errors like:

- `targeted OS version does not support use of thread local variables`
- `$MACOSX_DEPLOYMENT_TARGET mismatch: now "10.5" but "10.6" during configure`

Refs: #4

With this I am able to build on my OS X 10.9.5 system:

```
[marca@marca-mac2 jq.py]$ rm -rf build; python setup.py build
...
22 warnings generated.
creating build/lib.macosx-10.6-intel-2.7
/usr/bin/clang -bundle -undefined dynamic_lookup -arch i386 -arch x86_64 -g build/temp.macosx-10.6-intel-2.7/jq.o jq-jq-1.4/.libs/libjq.a -o build/lib.macosx-10.6-intel-2.7/jq.so
ld: warning: ignoring file jq-jq-1.4/.libs/libjq.a, file was built for archive which is not the architecture being linked (i386): jq-jq-1.4/.libs/libjq.a
[marca@marca-mac2 jq.py]$ ipython
Python 2.7.9 (v2.7.9:648dcafa7e5f, Dec 10 2014, 10:10:46)
Type "copyright", "credits" or "license" for more information.

IPython 2.3.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from jq import jq

In [2]: jq(".[]+1").transform([1, 2, 3], multiple_output=True)
Out[2]: [2, 3, 4]
```