### PR TITLE
README.rst: Add notes about OS X and Red Hat/etc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,10 @@ Therefore, installation requires any programs required to build jq.
 This includes:
 
 * The normal C compiler toolchain, such as gcc and make.
-  Installable on Debian, Ubuntu and relatives by installing the package ``build-essential``.
+
+  - Installable on Debian, Ubuntu and relatives by installing the package ``build-essential``.
+  - Installable on Red Hat/Fedora/CentOS/etc. with ``yum groupinstall "Development Tools"``.
+  - On Mac OS X, you probably want to install `Xcode <https://developer.apple.com/xcode/>`_.
 
 * Autoconf
 
@@ -21,16 +24,27 @@ This includes:
 
 * Bison
 
+  - At least some versions of Mac OS X ship a version of ``bison`` that is too old for ``jq`` to use.
+    If you have `Homebrew <http://brew.sh/>`_, try ``brew install bison``.
+
 * libtool
 
 * Python headers.
   Installable on Debian, Ubuntu and relatives by installing the package ``python-dev``.
-  
+
 If on Debian, Ubuntu or relatives, running the following packages should be sufficient:
 
 .. code-block:: sh
 
     apt-get install build-essential autoconf flex bison libtool python-dev
+
+If on Red Hat, Fedora, CentOS, etc., try:
+
+.. code-block:: sh
+
+    yum groupinstall "Development Tools"
+    yum install autoconf flex bison libtool python
+
 
 Usage
 -----


### PR DESCRIPTION
I don't have a Red Hat system handy to test on, so I'm winging it on that one, but someone else can correct it if it's wrong.

I stand behind the OS X advice since that's what I'm using.

Preview at https://github.com/msabramo/jq.py/blob/README_notes_about_OS_X_and_Red_Hat/README.rst