### PR TITLE
Support older autotools versions by building from true release source tarball

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,13 @@ def read(fname):
 
 
 tarball_path = path_in_dir("_jq-lib-1.4.tar.gz")
-jq_lib_dir = path_in_dir("jq-jq-1.4")
+jq_lib_dir = path_in_dir("jq-1.4")
 
 class jq_build_ext(build_ext):
     def run(self):
         if os.path.exists(tarball_path):
             os.unlink(tarball_path)
-        urlretrieve("https://github.com/stedolan/jq/archive/jq-1.4.tar.gz", tarball_path)
+        urlretrieve("https://stedolan.github.io/jq/download/source/jq-1.4.tar.gz", tarball_path)
         
         if os.path.exists(jq_lib_dir):
             shutil.rmtree(jq_lib_dir)
@@ -65,7 +65,6 @@ class jq_build_ext(build_ext):
         if macosx_deployment_target:
             os.environ['MACOSX_DEPLOYMENT_TARGET'] = macosx_deployment_target
 
-        command(["autoreconf", "-i"])
         command(["./configure"] + configure_args)
         command(["make"])
         


### PR DESCRIPTION
I've encountered a problem where I was unable to build jq.py on Scientific Linux 6.6 because of various m4 and automake macros not being supported by the available versions of autotools (m4 1.4.13, autoconf 2.63, automake 1.11.1). Because of this, the `autoreconf -i` command fails to complete:

```
$ python setup.py build
running build
running build_ext
Executing: autoreconf -i
configure.ac:11: warning: macro `AM_PROG_AR' not found in library
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, `config'.
libtoolize: copying file `config/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIR, `config/m4'.
libtoolize: copying file `config/m4/libtool.m4'
libtoolize: copying file `config/m4/ltoptions.m4'
libtoolize: copying file `config/m4/ltsugar.m4'
libtoolize: copying file `config/m4/ltversion.m4'
libtoolize: copying file `config/m4/lt~obsolete.m4'
configure.ac:11: warning: macro `AM_PROG_AR' not found in library
configure.ac:1: error: possibly undefined macro: m4_esyscmd_s
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:11: error: possibly undefined macro: AM_PROG_AR
autoreconf: /usr/bin/autoconf failed with exit status: 1
Traceback (most recent call last):
  File "setup.py", line 103, in <module>
    'Programming Language :: Python :: 3.4',
  File "/usr/lib64/python2.6/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/usr/lib64/python2.6/distutils/dist.py", line 975, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python2.6/distutils/dist.py", line 995, in run_command
    cmd_obj.run()
  File "/usr/lib64/python2.6/distutils/command/build.py", line 134, in run
    self.run_command(cmd_name)
  File "/usr/lib64/python2.6/distutils/cmd.py", line 333, in run_command
    self.distribution.run_command(command)
  File "/usr/lib64/python2.6/distutils/dist.py", line 995, in run_command
    cmd_obj.run()
  File "setup.py", line 68, in run
    command(["autoreconf", "-i"])
  File "setup.py", line 46, in command
    subprocess.check_call(args, cwd=jq_lib_dir)
  File "/usr/lib64/python2.6/subprocess.py", line 505, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['autoreconf', '-i']' returned non-zero exit status 1
```
The missing [AM_PROG_AR gets added in automake 1.11.2](https://lists.gnu.org/archive/html/info-gnu/2011-12/msg00008.html) and [m4_esyscmd_s gets added in autoconf 2.64](https://lists.gnu.org/archive/html/autotools-announce/2009-07/msg00000.html). According to rpmfind, CentOS 6.6 also is stuck on [autoconf 2.63](http://rpmfind.net/linux/rpm2html/search.php?query=autoconf) and [automake 1.11.1](http://rpmfind.net/linux/rpm2html/search.php?query=automake). Since there is [no upgrade path from SL6 to SL7](http://ftp.scientificlinux.org/linux/scientific/7rolling/x86_64/release-notes/#_upgrading_from_sl_6) and [CentOS 7 has only been out for about a year](https://en.wikipedia.org/wiki/CentOS#CentOS_releases), I'd guess that there are many servers still on 6.6 versions where jq.py currently cannot be installed.

The attached patch replaces the download link for the upstream jq package with the true release source package from the [jq download page](https://stedolan.github.io/jq/download/) that includes a pre-made `configure` script, thus making the `autoreconf -i` step unnecessary. With this, I can build jq.py fine on my ancient system. Since building from this tarball works just as well for jq.py, I would suggest changing to this source to make jq.py more broadly available to people that have to work on legacy operating systems :)