### PR TITLE
Fixed typo and added equivalent test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ separate line, irrespective of the value of ``multiple_output``:
 
 .. code-block:: python
 
-    jq(".[]").transform("[1, 2, 3]", text_output=True) == "1\n2\n3"
+    jq(".[]").transform(text="[1, 2, 3]", text_output=True) == "1\n2\n3"
 
 If ``multiple_output`` is ``False`` (the default), then the first output
 is used:

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ separate line, irrespective of the value of ``multiple_output``:
 
 .. code-block:: python
 
-    jq(".[]").transform(text="[1, 2, 3]", text_output=True) == "1\n2\n3"
+    jq(".[]").transform([1, 2, 3], text_output=True) == "1\n2\n3"
 
 If ``multiple_output`` is ``False`` (the default), then the first output
 is used:

--- a/tests/jq_tests.py
+++ b/tests/jq_tests.py
@@ -84,17 +84,6 @@ def value_error_is_raised_if_program_is_invalid():
 
 
 @istest
-def cannot_iterate_error_is_raised_if_input_is_string_and_not_parsed():
-    program = jq(".[]")
-    try:
-        program.transform("[1, 2, 3]")
-        assert False, "Expected error"
-    except ValueError as error:
-        expected_error_str = "jq: error: Cannot iterate over string"
-        assert_equal(str(error), expected_error_str)
-
-
-@istest
 def value_error_is_raised_if_input_cannot_be_processed_by_program():
     program = jq(".x")
     try:

--- a/tests/jq_tests.py
+++ b/tests/jq_tests.py
@@ -84,6 +84,17 @@ def value_error_is_raised_if_program_is_invalid():
 
 
 @istest
+def cannot_iterate_error_is_raised_if_input_is_string_and_not_parsed():
+    program = jq(".[]")
+    try:
+        program.transform("[1, 2, 3]")
+        assert False, "Expected error"
+    except ValueError as error:
+        expected_error_str = "jq: error: Cannot iterate over string"
+        assert_equal(str(error), expected_error_str)
+
+
+@istest
 def value_error_is_raised_if_input_cannot_be_processed_by_program():
     program = jq(".x")
     try:


### PR DESCRIPTION
Was thrown off by typo in example: JSON-string wasn't parsed (with text=).

Also added test to illustrate the problem.