### PR TITLE
Support for predefined variables

### DIFF
--- a/tests/jq_tests.py
+++ b/tests/jq_tests.py
@@ -137,3 +137,11 @@ def unicode_strings_can_be_used_as_programs():
         "Dragon‽",
         jq('.+"‽"').transform(text='"Dragon"')
     )
+
+
+@istest
+def compiling_with_args_should_set_predefined_variables():
+    assert_equal(
+        6,
+        jq('$a + $b + .', args={'a': 1, 'b': 2}).transform(3)
+    )


### PR DESCRIPTION
This adds support for compiling a program with predefined variables.

```python
>>> jq('$a + $b + .', args={'a': 1, 'b': 2}).transform(3)
6
```