### PR TITLE
README: Add python-devel package for Fedora

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ If on Red Hat, Fedora, CentOS, or relatives, running the following command shoul
 .. code-block:: sh
 
     yum groupinstall "Development Tools"
-    yum install autoconf automake libtool python
+    yum install autoconf automake libtool python python-devel
 
 Mac OS X
 ~~~~~~~~


### PR DESCRIPTION
Fedora install fails with just the installation of packages mentioned on PyPi. `python-devel` is also required.