### PR TITLE
Add support for build via standard setuptools / setup.py

### DIFF
--- a/jq.pyx
+++ b/jq.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=3
 import json
 
 

--- a/makefile
+++ b/makefile
@@ -11,14 +11,14 @@ test: bootstrap
 upload: jq.c
 	python setup.py sdist upload
 	make clean
-	
+
 register:
 	python setup.py register
 
 clean:
-	rm -f MANIFEST
-	rm -rf dist
-	
+	rm -f MANIFEST *gz
+	rm -rf dist jq-jq-* *.egg-info
+
 bootstrap: _virtualenv jq.c
 	_virtualenv/bin/pip install -e .
 ifneq ($(wildcard test-requirements.txt),) 

--- a/makefile
+++ b/makefile
@@ -1,3 +1,8 @@
+#
+# Updated cython version to 0.29.16, the make was failing
+# using the version it was previously pinned on, even on
+# x86_64
+#
 .PHONY: test test-all upload register clean bootstrap
 
 test: bootstrap
@@ -27,5 +32,5 @@ _virtualenv:
 	_virtualenv/bin/pip install --upgrade setuptools
 
 jq.c: _virtualenv jq.pyx
-	_virtualenv/bin/pip install cython==0.19.2
+	_virtualenv/bin/pip install cython==0.29.16
 	_virtualenv/bin/cython jq.pyx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython"]
+build-backend = "setuptools.build_meta"
+

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ class jq_build_ext(_build_ext):
             tarball_path=oniguruma_lib_tarball_path,
             lib_dir=oniguruma_lib_build_dir,
             commands=[
-                ["autoreconf", "-i", "-f", "-W", "none"],
+#                ["autoreconf", "-i", "-f", "-W", "none"],
                 ["./configure", "CFLAGS=-fPIC", "--prefix=" + oniguruma_lib_install_dir],
                 ["make"],
                 ["make", "install"],

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ class jq_build_ext(_build_ext):
             tarball_path=oniguruma_lib_tarball_path,
             lib_dir=oniguruma_lib_build_dir,
             commands=[
-#                ["autoreconf", "-i", "-f", "-W", "none"],
+                ["touch", "NEWS", "ChangeLog"],
+                ["autoreconf", "-i", "-f", "-W", "none"],
                 ["./configure", "CFLAGS=-fPIC", "--prefix=" + oniguruma_lib_install_dir],
                 ["make"],
                 ["make", "install"],


### PR DESCRIPTION
This update changes a few things, mostly as a solution to #41 

- Adds the ability for `pip install` to perform a successful build from source when there is no binary wheel available (e.g. on ppc64le/Linux platform)
- Fixes the `makefile` which appears to have become broken. On x86_64, `make` now works again
- `pip install .` works on both x86_64 and ppc64le (all I could test) without conditionals in setup.py

You can test the new "features" and for regressions using the following for x86_64:

- `make` (the original release system)
- `pip install --no-binary :all: -e 'git+https://github.com/mzpqnxow/jq.py@setuptools-build#egg=jq'`
- `git clone https://github.com/mzpqnxow/jq.py --branch setuptools-build && cd jq.py && pip install .`

I also tested the above on the ppc64le/Linux system I have. I don't see any reason the changes should affect other platforms, but I'm sure you will want to do some of your own regression testing before considering this.

I believe building via `pip` / directly via `setup.py` was not intended by design, but I've added it out of necessity for deploy-time builds on ppc64le

*NOTE*: There is also no longer a requirement for a temporary virtual environment or installation of cython in a system or user environment, so that can be removed from the build/release makefile as well. The `pyproject.toml` addition actually works as PEP518 describes and will temporarily pull down cython at build-time without installing it persistently in any location. See the `pyproject.toml` file which is intuitive once you get it correct

If you're not interested in accepting this, please close this out and I will maintain my own fork. Either way, thanks for your time and thanks for the excellent project!
