### PR TITLE
> 32bit integer support.

### DIFF
--- a/jq.pyx
+++ b/jq.pyx
@@ -80,10 +80,9 @@ cdef object _jv_to_python(jv value):
     elif kind == JV_KIND_TRUE:
         python_value = True
     elif kind == JV_KIND_NUMBER:
-        if jv_is_integer(value):
+        python_value = float(jv_number_value(value))
+        if(python_value.is_integer()):
             python_value = int(jv_number_value(value))
-        else:
-            python_value = float(jv_number_value(value))
     elif kind == JV_KIND_STRING:
         python_value = jv_string_value(value).decode("utf-8")
     elif kind == JV_KIND_ARRAY:


### PR DESCRIPTION
> 32 bit integers get parsed and returned as strings.  This patch will allow large integers.

### Test Plan

```
>>> import jq
>>> jq.compile(".").input({"foo": 9007199254740991}).first()
{'foo': 9007199254740991}
>>> jq.compile(".").input({"foo": 2147483647}).first()
{'foo': 2147483647}
>>> jq.compile(".").input({"foo": 2147483648}).first()
{'foo': 2147483648}
>>> jq.compile(".").input({"foo": 2147483648.5}).first()
{'foo': 2147483648.5}
>>> jq.compile(".").input({"foo": 9007199254740991.5}).first()
{'foo': 9007199254740992}
```

Note the really big numbers are rounded and don't display decimal.  This is inline with what JQ 1.6 does.

```
abc@e726e387ee2c:/tmp$ echo '{"foo": 9007199254740991.2}' | ./jq-linux64 '.'
{
  "foo": 9007199254740991
}
abc@e726e387ee2c:/tmp$ echo '{"foo": 9007199254740991.5}' | ./jq-linux64 '.'                                                                                                                           
{
  "foo": 9007199254740992
}
abc@e726e387ee2c:/tmp$ ./jq-linux64 --version
jq-1.6
abc@e726e387ee2c:/tmp$ 
```