### PR TITLE
Add license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+include LICENSE


### PR DESCRIPTION
Ensure that the license file is part of the source tarball published on PyPI.

It would be nice if you could create a new release after merging because some distributions require to ship the license file, e. g. Fedora. Would allow ArchLinux to get rid rid of the [separate request](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-jq) for the file.

Thanks