### PR TITLE
ci: some cleanup and updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Use Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -30,7 +30,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
         name: Use Python 3.7
@@ -47,7 +47,7 @@ jobs:
       - name: Check metadata
         run: python -m twine check dist/*
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -60,15 +60,10 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
-
-      - name: Use Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
+      - uses: actions/checkout@v3
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.10.1
+        run: pipx install cibuildwheel==2.11.2
 
       - id: set-matrix
         env:
@@ -78,9 +73,9 @@ jobs:
           MATRIX=$(
             {
               cibuildwheel --print-build-identifiers --platform linux \
-                | sed 's/.*/{"cibw-only": "&", "os": "ubuntu-20.04"}/' \
+                | jq --raw-input --compact-output --null-input '{"cibw-only": inputs, "os": "ubuntu-20.04"}' \
               && cibuildwheel --print-build-identifiers --platform macos \
-                | sed 's/.*/{"cibw-only": "&", "os": "macos-11" }/'
+                | jq --raw-input --compact-output --null-input '{"cibw-only": inputs, "os": "macos-11"}'
             } | jq --slurp --compact-output '{"include": .}'
           )
           echo matrix="$MATRIX" >> $GITHUB_OUTPUT
@@ -97,12 +92,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
-
-    - name: Use Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
+    - uses: actions/checkout@v3
 
     - name: Set up QEMU
       if: runner.os == 'Linux'
@@ -110,18 +100,13 @@ jobs:
       with:
         platforms: all
 
-    - name: Print build identifiers
-      run: |
-        python -m pip install cibuildwheel==2.10.1
-        python -m cibuildwheel --only ${{ matrix.cibw-only }} --print-build-identifiers
-
     - name: Build wheels
       if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' }}
-      uses: pypa/cibuildwheel@v2.10.1
+      uses: pypa/cibuildwheel@v2.11.2
       with:
         only: ${{ matrix.cibw-only }}
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' }}
       with:
         path: ./wheelhouse/*.whl


### PR DESCRIPTION
Adds some updates (GHA is deprecating node 12, which is used on some of the older actions, see deprecation warnings) and simplifies a bit. There are some extra actions that are not needed and could potentially interfere with cibuildwheel.