### PR TITLE
env var to get jq from environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,20 @@ jq_extension = Extension(
         os.path.join(oniguruma_lib_install_dir, "lib/libonig.a"),
     ],
 )
+setup_kwargs = {}
+
+if os.environ.get("JQPY_USE_SYSTEM_LIBRARIES"):
+    jq_extension = Extension(
+        "jq",
+        sources=["jq.c"],
+        libraries=["jq"],
+    )
+else:
+    setup_kwargs = {
+        "cmdclass": {
+            "build_ext": jq_build_ext,
+        },
+    }
 
 setup(
     name='jq',
@@ -104,7 +118,6 @@ setup(
     python_requires='>=3.5',
     license='BSD 2-Clause',
     ext_modules = [jq_extension],
-    cmdclass={"build_ext": jq_build_ext},
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -119,5 +132,5 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
     ],
+    **setup_kwargs,
 )
-

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,8 @@ setup_kwargs = {}
 if os.environ.get("JQPY_USE_SYSTEM_LIBRARIES"):
     jq_extension = Extension(
         "jq",
-        sources=["jq.c"],
+        sources=[],
+        headers=["jq.h"],
         libraries=["jq"],
     )
 else:


### PR DESCRIPTION
I think this addresses https://github.com/mwilliamson/jq.py/issues/81

I'll also need to make a corresponding change to https://github.com/nix-community/poetry2nix/blob/master/overrides/default.nix#L889 so that it stops applying the patch and start using the env var instead.

If JQPY_USE_SYSTEM_LIBRARIES is unset, everything should be as it was before--so (if accepted), this can go first and I can figure out the poetry2nix side of things later.

I still need to figure out how to test it though, so it's a draft for now.