### PR TITLE
Upgrade Cython Version to Support Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-11]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "pypy-3.7"]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev", "pypy-3.7"]
 
     steps:
 

--- a/makefile
+++ b/makefile
@@ -28,5 +28,5 @@ _virtualenv:
 	_virtualenv/bin/pip install --upgrade wheel
 
 jq.c: _virtualenv jq.pyx
-	_virtualenv/bin/pip install cython==0.29.32
+	_virtualenv/bin/pip install cython==0.29.35
 	_virtualenv/bin/cython jq.pyx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 before-build = [
-    "pip install cython==0.29.32",
+    "pip install cython==0.29.35",
     "cython {project}/jq.pyx",
 ]
 test-requires = "-r test-requirements.txt"


### PR DESCRIPTION
I am preparing our library for 3.12 which relies on `jq`. We turned on our CI for 3.12 beta and it was failing to compile `jq`. When debugging, it seems that upgrading to the latest `cython==0.29.35` was able to resolve the issue. Presumably due to compatibility improvements in cython with the 3.12 abi. 

Not hugely familiar with the c-extensions side of python. Let me know what you think.

Cheers! 