### PR TITLE
Implement library/module lookup paths

### DIFF
--- a/tests/jq_lib/test_module.jq
+++ b/tests/jq_lib/test_module.jq
@@ -1,0 +1,6 @@
+module {
+  "name": "test_module"
+};
+
+def increment: . + 1;
+def constant_str: "constant";

--- a/tests/jq_library_path_tests.py
+++ b/tests/jq_library_path_tests.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import jq
+from .tools import assert_equal, assert_is
+
+JQ_LIB_PATH = Path(__file__).parent / 'jq_lib'
+
+
+def test_include_increment():
+    exp = 'include "test_module"; . | increment'
+    assert_equal(
+        11,
+        jq.compile(exp, library_search_path=[JQ_LIB_PATH]).input(10).first()
+    )
+
+
+def test_import_contant():
+    exp = 'import "test_module" as test; . | test::constant_str'
+    assert_equal(
+        "constant",
+        jq.compile(exp, library_search_path=[JQ_LIB_PATH]).input("test").first()
+    )
+


### PR DESCRIPTION
`library_search_path` can be passed to `jq.compile()` for module lookup.

The same default values for `library_search_path` as in the jq CLI are used if none provided.