### PR TITLE
Fix wrong declaration of jv_string_value

### DIFF
--- a/jq.pyx
+++ b/jq.pyx
@@ -27,7 +27,7 @@ cdef extern from "jv.h":
     void jv_free(jv)
     jv jv_invalid_get_msg(jv)
     int jv_invalid_has_msg(jv)
-    char* jv_string_value(jv)
+    const char* jv_string_value(jv)
     jv jv_dump_string(jv, int flags)
     int jv_string_length_bytes(jv)
     int jv_is_integer(jv)
@@ -420,5 +420,5 @@ def jq(object program):
 
 cdef unicode jv_string_to_py_string(jv value):
     cdef int length = jv_string_length_bytes(jv_copy(value))
-    cdef char* string_value = jv_string_value(value)
+    cdef const char* string_value = jv_string_value(value)
     return string_value[:length].decode("utf-8")


### PR DESCRIPTION
Currently, there is a warning when building wheel.
```
jq.c: In function ‘__pyx_f_2jq_jv_string_to_py_string’:
jq.c:12111:24: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
12111 |   __pyx_v_string_value = jv_string_value(__pyx_v_value);
      |
```

This is because the type of return value of `jv_string_value` is `const char *` instead of `char *`. This is not an API change. The function returns `const char *` when it becomes available.