### PR TITLE
Windows wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-13]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "pypy-3.7"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "pypy-3.7"]
         use-system-libs: [false]
         include:
           - os: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,6 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: "auto aarch64"
           CIBW_ARCHS_MACOS: "auto"
-
         run: |
           MATRIX=$(
             {
@@ -141,13 +140,13 @@ jobs:
         python -m cibuildwheel --only ${{ matrix.cibw-only }} --print-build-identifiers
 
     - name: Build wheels
-      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' }}
+      if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' }}
       uses: pypa/cibuildwheel@v2.17.0
       with:
         only: ${{ matrix.cibw-only }}
 
     - uses: actions/upload-artifact@v3
-      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' }}
+      if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' }}
       with:
         path: ./wheelhouse/*.whl
 
@@ -205,7 +204,7 @@ jobs:
         python -m cibuildwheel --only ${{ matrix.cibw-only }} --print-build-identifiers
 
     - name: Build wheels
-      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp311-win_amd64' }}
+      if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp311-win_amd64' }}
       uses: pypa/cibuildwheel@v2.17.0
       with:
         only: ${{ matrix.cibw-only }}
@@ -213,7 +212,7 @@ jobs:
         CIBW_ENVIRONMENT:  JQPY_USE_PREBUILT_LIBS=1 ${{ contains(matrix.cibw-only, 'win32') && 'CC=i686-w64-mingw32-gcc.exe' || '' }}
 
     - uses: actions/upload-artifact@v3
-      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp311-win_amd64' }}
+      if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp311-win_amd64' }}
       with:
         path: ./wheelhouse/*.whl
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,14 +89,15 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: "auto aarch64"
           CIBW_ARCHS_MACOS: "auto"
+
         run: |
           MATRIX=$(
             {
               cibuildwheel --print-build-identifiers --platform linux \
-                | sed 's/.*/{"cibw-only": "&", "os": "ubuntu-20.04"}/' \
+              | sed 's/.*/{"cibw-only": "&", "os": "ubuntu-20.04"}/' \
               && cibuildwheel --print-build-identifiers --platform macos \
                 | sed 's/.*/{"cibw-only": "&", "os": "macos-13" }/' \
-              && cibuildwheel --print-build-identifiers --platform windows \
+              && env CIBW_SKIP="pp* cp36*" cibuildwheel --print-build-identifiers --platform windows \
                 | sed 's/.*/{"cibw-only": "&", "os": "windows-latest" }/' 
             } | jq --slurp --compact-output '{"include": .}'
           )
@@ -127,22 +128,23 @@ jobs:
       with:
         platforms: all
 
-    - name: Set up MSYS
+    - name: set up MSYS2
       if: runner.os == 'Windows'
       uses: msys2/setup-msys2@v2
       with:
-        msystem: UCRT64
-        update: true
-        install: mingw-w64-ucrt-x86_64-gcc make
+        release: false
+        msystem: ${{ contains(matrix.cibw-only, 'win32') && 'mingw32' || 'ucrt64' }}
+        install: make mingw-w64-${{ contains(matrix.cibw-only, 'win32') && 'i686' || 'ucrt-x86_64' }}-gcc
 
-    - name: Setup windows build environment
+    - name: Setup windows build variables
       id: setup-build-win
       if: runner.os == 'Windows'
-      shell: msys2 {0}
+      shell:  msys2 {0}
       run: |
         JQ_VERSION=$(ls deps/jq-*.tar.gz | grep -oP 'jq-\K[\d.]+(?=.tar.gz)') 
         echo jq-lib-version="$JQ_VERSION" >> $GITHUB_OUTPUT
-        echo use-prebuilt-jq=1 >>$GITHUB_OUTPUT
+        echo arch=$( grep -o 'win_amd64\|win32' <<< ${{matrix.cibw-only}}) >> $GITHUB_OUTPUT
+        ${{ contains(matrix.cibw-only, 'win32') && 'echo "C:/msys64/mingw32/bin" >> $GITHUB_PATH' || 'echo no need to set PATH for win_amd64' }}
         printf "[build]\ncompiler=mingw32" > setup.cfg
 
     - name: Cache pre-built jq lib
@@ -151,13 +153,12 @@ jobs:
       uses: actions/cache@v4
       with:
         path: _deps/build
-        key: ${{ runner.os }}-prebuilt-jq-${{steps.setup-build-win.outputs.jq-lib-version}}
+        key: prebuilt-jq-${{steps.setup-build-win.outputs.jq-lib-version}}-${{ steps.setup-build-win.outputs.arch }}
   
     - name: Build jq lib
       if: runner.os == 'Windows' && steps.cache-prebuilt-jq.outputs.cache-hit != 'true'
       shell: msys2 {0}
-      run: |
-        make -f build_jq.mk
+      run: make -f build_jq.mk
 
     - name: Print build identifiers
       run: |
@@ -165,20 +166,20 @@ jobs:
         python -m cibuildwheel --only ${{ matrix.cibw-only }} --print-build-identifiers
 
     - name: Build wheels
-      if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' || matrix.cibw-only == 'cp311-win_amd64' }}
+      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' || matrix.cibw-only == 'cp311-win_amd64' }}
       uses: pypa/cibuildwheel@v2.17.0
       with:
         only: ${{ matrix.cibw-only }}
       env:
-        CIBW_ENVIRONMENT: JQPY_USE_PREBUILT_LIBS="${{steps.setup-build-win.outputs.use-prebuilt-jq }}"
+        CIBW_ENVIRONMENT: ${{ runner.os == 'Windows' && 'JQPY_USE_PREBUILT_LIBS' || '' }} ${{ contains(matrix.cibw-only, 'win32') && 'CC=i686-w64-mingw32-gcc.exe' || '' }}
+
     - uses: actions/upload-artifact@v3
-      if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' || matrix.cibw-only == 'cp311-win_amd64' }}
+      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' || matrix.cibw-only == 'cp311-win_amd64' }}
       with:
         path: ./wheelhouse/*.whl
 
   build_wheels_macosx_arm64:
     name: Build macOS arm64 wheels
-
     runs-on: macos-14
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,9 @@ jobs:
               cibuildwheel --print-build-identifiers --platform linux \
                 | sed 's/.*/{"cibw-only": "&", "os": "ubuntu-20.04"}/' \
               && cibuildwheel --print-build-identifiers --platform macos \
-                | sed 's/.*/{"cibw-only": "&", "os": "macos-13" }/'
+                | sed 's/.*/{"cibw-only": "&", "os": "macos-13" }/' \
+              && cibuildwheel --print-build-identifiers --platform windows \
+                | sed 's/.*/{"cibw-only": "&", "os": "windows-latest" }/' 
             } | jq --slurp --compact-output '{"include": .}'
           )
           echo matrix="$MATRIX" >> $GITHUB_OUTPUT
@@ -125,19 +127,52 @@ jobs:
       with:
         platforms: all
 
+    - name: Set up MSYS
+      if: runner.os == 'Windows'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: true
+        install: mingw-w64-ucrt-x86_64-gcc make
+
+    - name: Setup windows build environment
+      id: setup-build-win
+      if: runner.os == 'Windows'
+      shell: msys2 {0}
+      run: |
+        JQ_VERSION=$(ls deps/jq-*.tar.gz | grep -oP 'jq-\K[\d.]+(?=.tar.gz)') 
+        echo jq-lib-version="$JQ_VERSION" >> $GITHUB_OUTPUT
+        echo use-prebuilt-jq=1 >>$GITHUB_OUTPUT
+        printf "[build]\ncompiler=mingw32" > setup.cfg
+
+    - name: Cache pre-built jq lib
+      if: runner.os == 'Windows'
+      id: cache-prebuilt-jq
+      uses: actions/cache@v4
+      with:
+        path: _deps/build
+        key: ${{ runner.os }}-prebuilt-jq-${{steps.setup-build-win.outputs.jq-lib-version}}
+  
+    - name: Build jq lib
+      if: runner.os == 'Windows' && steps.cache-prebuilt-jq.outputs.cache-hit != 'true'
+      shell: msys2 {0}
+      run: |
+        make -f build_jq.mk
+
     - name: Print build identifiers
       run: |
         python -m pip install cibuildwheel==2.17.0
         python -m cibuildwheel --only ${{ matrix.cibw-only }} --print-build-identifiers
 
     - name: Build wheels
-      if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' }}
+      if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' || matrix.cibw-only == 'cp311-win_amd64' }}
       uses: pypa/cibuildwheel@v2.17.0
       with:
         only: ${{ matrix.cibw-only }}
-
+      env:
+        CIBW_ENVIRONMENT: JQPY_USE_PREBUILT_LIBS="${{steps.setup-build-win.outputs.use-prebuilt-jq }}"
     - uses: actions/upload-artifact@v3
-      if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' }}
+      if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' || matrix.cibw-only == 'cp311-win_amd64' }}
       with:
         path: ./wheelhouse/*.whl
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix_win: ${{ steps.set-matrix.outputs.matrix_win }}
 
     steps:
 
@@ -94,14 +95,20 @@ jobs:
           MATRIX=$(
             {
               cibuildwheel --print-build-identifiers --platform linux \
-              | sed 's/.*/{"cibw-only": "&", "os": "ubuntu-20.04"}/' \
+                | sed 's/.*/{"cibw-only": "&", "os": "ubuntu-20.04"}/' \
               && cibuildwheel --print-build-identifiers --platform macos \
-                | sed 's/.*/{"cibw-only": "&", "os": "macos-13" }/' \
-              && env CIBW_SKIP="pp* cp36*" cibuildwheel --print-build-identifiers --platform windows \
-                | sed 's/.*/{"cibw-only": "&", "os": "windows-latest" }/' 
+                | sed 's/.*/{"cibw-only": "&", "os": "macos-13" }/'
             } | jq --slurp --compact-output '{"include": .}'
           )
           echo matrix="$MATRIX" >> $GITHUB_OUTPUT
+
+          MATRIX_WIN=$(
+            {
+              env CIBW_SKIP="pp* cp36*" cibuildwheel --print-build-identifiers --platform windows \
+              | sed 's/.*/{"cibw-only": "&", "os": "windows-latest" }/' 
+            } | jq --slurp --compact-output '{"include": .}'
+          )
+          echo matrix_win="$MATRIX_WIN" >> $GITHUB_OUTPUT
 
   build_wheels:
     name: Build ${{ matrix.cibw-only }} wheel
@@ -128,8 +135,42 @@ jobs:
       with:
         platforms: all
 
+    - name: Print build identifiers
+      run: |
+        python -m pip install cibuildwheel==2.17.0
+        python -m cibuildwheel --only ${{ matrix.cibw-only }} --print-build-identifiers
+
+    - name: Build wheels
+      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' }}
+      uses: pypa/cibuildwheel@v2.17.0
+      with:
+        only: ${{ matrix.cibw-only }}
+
+    - uses: actions/upload-artifact@v3
+      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' }}
+      with:
+        path: ./wheelhouse/*.whl
+
+  build_wheels_win:
+    name: Build ${{ matrix.cibw-only }} wheel
+
+    needs: build_wheels_matrix
+
+    strategy:
+      matrix: ${{ fromJson(needs.build_wheels_matrix.outputs.matrix_win) }}
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Use Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
     - name: set up MSYS2
-      if: runner.os == 'Windows'
       uses: msys2/setup-msys2@v2
       with:
         release: false
@@ -138,7 +179,6 @@ jobs:
 
     - name: Setup windows build variables
       id: setup-build-win
-      if: runner.os == 'Windows'
       shell:  msys2 {0}
       run: |
         JQ_VERSION=$(ls deps/jq-*.tar.gz | grep -oP 'jq-\K[\d.]+(?=.tar.gz)') 
@@ -148,7 +188,6 @@ jobs:
         printf "[build]\ncompiler=mingw32" > setup.cfg
 
     - name: Cache pre-built jq lib
-      if: runner.os == 'Windows'
       id: cache-prebuilt-jq
       uses: actions/cache@v4
       with:
@@ -156,7 +195,7 @@ jobs:
         key: prebuilt-jq-${{steps.setup-build-win.outputs.jq-lib-version}}-${{ steps.setup-build-win.outputs.arch }}
   
     - name: Build jq lib
-      if: runner.os == 'Windows' && steps.cache-prebuilt-jq.outputs.cache-hit != 'true'
+      if: steps.cache-prebuilt-jq.outputs.cache-hit != 'true'
       shell: msys2 {0}
       run: make -f build_jq.mk
 
@@ -166,15 +205,15 @@ jobs:
         python -m cibuildwheel --only ${{ matrix.cibw-only }} --print-build-identifiers
 
     - name: Build wheels
-      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' || matrix.cibw-only == 'cp311-win_amd64' }}
+      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp311-win_amd64' }}
       uses: pypa/cibuildwheel@v2.17.0
       with:
         only: ${{ matrix.cibw-only }}
       env:
-        CIBW_ENVIRONMENT: ${{ runner.os == 'Windows' && 'JQPY_USE_PREBUILT_LIBS' || '' }} ${{ contains(matrix.cibw-only, 'win32') && 'CC=i686-w64-mingw32-gcc.exe' || '' }}
+        CIBW_ENVIRONMENT:  JQPY_USE_PREBUILT_LIBS=1 ${{ contains(matrix.cibw-only, 'win32') && 'CC=i686-w64-mingw32-gcc.exe' || '' }}
 
     - uses: actions/upload-artifact@v3
-      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp310-manylinux_x86_64' || matrix.cibw-only == 'cp311-win_amd64' }}
+      # if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) || matrix.cibw-only == 'cp311-win_amd64' }}
       with:
         path: ./wheelhouse/*.whl
 

--- a/build_jq.mk
+++ b/build_jq.mk
@@ -1,9 +1,9 @@
 # makefile for building jq
-
-.PHONY: jq_tarball jq_src jq_lib
+.PHONY: jq_tarball jq_src jq_lib clean
 
 jq_build_parent:=_deps/build
-jq_version=$(shell echo $(shell ls deps/jq-*.tar.gz) | grep -oP 'jq-\K[\d.]+(?=.tar.gz)')
+
+jq_version:=$(shell echo $(shell ls deps/jq-*.tar.gz) | grep -oP 'jq-\K[\d.]+(?=.tar.gz)')
 jq_tarball_path:=deps/jq-$(jq_version).tar.gz
 jq_build_path:=$(jq_build_parent)/jq-$(jq_version)
 

--- a/build_jq.mk
+++ b/build_jq.mk
@@ -1,0 +1,29 @@
+# makefile for building jq
+
+.PHONY: jq_tarball jq_src jq_lib
+
+jq_build_parent:=_deps/build
+jq_version=$(shell echo $(shell ls deps/jq-*.tar.gz) | grep -oP 'jq-\K[\d.]+(?=.tar.gz)')
+jq_tarball_path:=deps/jq-$(jq_version).tar.gz
+jq_build_path:=$(jq_build_parent)/jq-$(jq_version)
+
+all: $(jq_build_path)/.libs/libjq.a $(jq_build_path)/modules/oniguruma/src/.libs/libonig.a
+
+jq_tarball: $(jq_tarball_path)
+	echo "found jq tarball: $(jq_tarball_path)"
+	
+jq_src: jq_tarball
+	# extract tarball to jq_build_path
+	mkdir -p $(jq_build_path)
+	tar -xf $(jq_tarball_path) -C $(jq_build_parent)
+
+$(jq_build_path)/.libs/libjq.a $(jq_build_path)/modules/oniguruma/src/.libs/libonig.a: jq_lib
+
+jq_lib: jq_src 
+	# build jq
+	cd $(jq_build_path) ; \
+	./configure CFLAGS="-fPIC -pthread" --disable-maintainer-mode --with-oniguruma=builtin; \
+	make
+
+clean:
+	rm -rf $(jq_build_parent)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import sys
 import subprocess
 import tarfile
 import shutil
@@ -67,6 +68,8 @@ class jq_with_deps_build_ext(build_ext):
 
 use_system_libs = bool(os.environ.get("JQPY_USE_SYSTEM_LIBS"))
 use_prebuilt_libs = bool(os.environ.get("JQPY_USE_PREBUILT_LIBS"))
+print(f"use_system_libs={use_system_libs}")
+print(f"use_prebuilt_libs={use_prebuilt_libs}")
 
 if use_system_libs:
     jq_build_ext = build_ext
@@ -80,11 +83,10 @@ else:
         os.path.join(jq_lib_dir, "modules/oniguruma/src/.libs/libonig.a"),
     ]
 
-
 jq_extension = Extension(
     "jq",
     sources=["jq.c"],
-    define_macros=[("MS_WIN64", 1)] if os.name == 'nt' else [],
+    define_macros=[("MS_WIN64" , 1)] if os.name == 'nt' and sys.maxsize > 2**32  else None, # https://github.com/cython/cython/issues/2670
     include_dirs=[os.path.join(jq_lib_dir, "src")],
     extra_link_args=["-lm"] + (["-Wl,-Bstatic", "-lpthread", "-lshlwapi", "-static-libgcc"] if os.name == 'nt' else []) + link_args_deps,
     extra_objects=extra_objects,

--- a/tests/jq_old_tests.py
+++ b/tests/jq_old_tests.py
@@ -79,6 +79,10 @@ def test_value_error_is_raised_if_program_is_invalid():
             "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
             # jq 1.7
             "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting end of file (Unix shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
+            # jq 1.6 -win
+            "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Windows cmd shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
+            # jq 1.7 -win
+            "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting end of file (Windows cmd shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
         ]
         assert str(error) in expected_error_strs
 

--- a/tests/jq_tests.py
+++ b/tests/jq_tests.py
@@ -199,6 +199,10 @@ def test_value_error_is_raised_if_program_is_invalid():
             "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
             # jq 1.7
             "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting end of file (Unix shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
+            # jq 1.6 -win
+            "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Windows cmd shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
+            # jq 1.7 -win
+            "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting end of file (Windows cmd shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
         ]
         assert str(error) in expected_error_strs
 


### PR DESCRIPTION
Added support for building windows wheels (cp37~cp312, win_amd64/win32). Should fix #20, partially?

The reason it cannot be done directly is that the building toolchain used by upstream [jq](https://github.com/jqlang/jq) can only run on a unix-like system. 

Thankfully, [MSYS2](https://www.msys2.org/) provides a compatible environment to do that on windows. However, we cannot build jqpy entirely under MSYS2 along with lib jq due to [some naming and linking issues](https://github.com/mwilliamson/jq.py/issues/20#issuecomment-2118669913) mentioned previously.

Therefore, a possible workflow is to build lib jq under MSYS2 first, and then build the jqpy wheel linking to that (using standard MSVC python distribution, not the python in MSYS2). 

MinGW GCC is used in above process. It has to be noted, that there does exist some possibilities of potential incompatibilities when the wheels are installed to python built with MSVC, but filling the blank of functional wheels for windows users should come with higher priority.

Changes:

1. A makefile `build_jq.mk` for building the jq library under MSYS2. (It should work on other systems as well)
2. Modified `setup.py`, adding support to use a pre-built jq library, and some additional options required on windows.
3. Modified `jq_tests.py` and `jq_old_tests.py`. Extended `expected_strings` for windows in `test_value_error_is_raised_if_program_is_invalid()`. Now the wheel is supposed to pass all tests on windows.
4. Modified github action workflow `build.yml`, adding a job `build_wheel_win` for building windows wheels.
5. Remove python version 3.5 from the workflow job `tests`, as we no longer build wheels for it (deprecated by [cibuildwheel at v2.0.0](https://cibuildwheel.pypa.io/en/stable/changelog/#v200)). And it causes `setup-python` action to fail recently (see [this issue](https://github.com/actions/setup-python/issues/866)).

For review and testing purposes, a full workflow run building wheels for all python versions and arches can be viewed [here](https://github.com/du33169/jq.py/actions/runs/9207257301), with [its built wheels](https://github.com/du33169/jq.py/actions/runs/9207257301/artifacts/1530830013). The latest commit maintains consistency with the original build strategy(only build all wheels on tag push).

Additional Notes:

- The built jq lib files will be cached(per jq version and arch) for speeding up the workflow. Currently this is only enabled(and required) for building windows wheels, but it can also be employed on other systems.
- I am not familiar with tox, so the workflow job named `tests` was not extended for windows. But I do notice that cibuildwheel will also run the tests on built wheels.
- Failed to build wheels for CPython3.6 on windows. There is a workaround that to patch `[python root]\lib\distutils\cygwinccompiler.py`([from here](https://bugs.python.org/issue25251#msg251758)). Currently this is not employed in this PR, and I personally don't recommend it.
- Failed to build wheels for PyPy on windows, reporting `cannot find -lvcruntime140: no such file or directory`. I'm also not familiar with PyPy so this remains unresolved for now.

Acknowledgment:

This PR is initially inspired by @jknockel, who provided [major instructions for building jqpy on windows](https://github.com/mwilliamson/jq.py/issues/20#issuecomment-1784256183).
