### PR TITLE
ci: build for CPython 3.13, test built all Pypy versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-13]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13-dev", "pypy-3.7"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13-dev", "pypy-3.7", "pypy-3.8", "pypy-3.9", "pypy-3.10"]
         use-system-libs: [false]
         include:
           - os: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-13]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "pypy-3.7"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13-dev", "pypy-3.7"]
         use-system-libs: [false]
         include:
           - os: ubuntu-20.04
@@ -84,13 +84,14 @@ jobs:
           python-version: '3.11'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.17.0
+        run: python -m pip install cibuildwheel==2.19.2
 
       - id: set-matrix
         env:
           CIBW_ARCHS_LINUX: "auto aarch64"
           CIBW_ARCHS_MACOS: "auto"
           CIBW_SKIP: "cp36-win_amd64 cp36-win32 pp*-win_amd64 pp*-win32"
+          CIBW_PRERELEASE_PYTHONS: "True" # XXX Can be removed on cibuildwheel 2.20
         run: |
           MATRIX=$(
             {
@@ -145,7 +146,7 @@ jobs:
 
     - name: Build wheels
       if: steps.should-build-wheel.outputs.true
-      uses: pypa/cibuildwheel@v2.17.0
+      uses: pypa/cibuildwheel@v2.19.2
       with:
         only: ${{ matrix.cibw-only }}
       env:
@@ -172,18 +173,18 @@ jobs:
 
     - name: Print build identifiers
       run: |
-        python -m pip install cibuildwheel==2.17.0
+        python -m pip install cibuildwheel==2.19.2
         CIBW_SKIP=cp38-macosx_arm64 python -m cibuildwheel --print-build-identifiers
 
     - name: Build wheels
       if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) }}
-      uses: pypa/cibuildwheel@v2.17.0
+      uses: pypa/cibuildwheel@v2.19.2
       env:
         CIBW_SKIP: cp38-macosx_arm64
 
     - name: Build wheels
       if: ${{ !(github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) }}
-      uses: pypa/cibuildwheel@v2.17.0
+      uses: pypa/cibuildwheel@v2.19.2
       with:
         only: cp310-macosx_arm64
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,14 +84,13 @@ jobs:
           python-version: '3.11'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.19.2
+        run: python -m pip install cibuildwheel==2.20.0
 
       - id: set-matrix
         env:
           CIBW_ARCHS_LINUX: "auto aarch64"
           CIBW_ARCHS_MACOS: "auto"
           CIBW_SKIP: "cp36-win_amd64 cp36-win32 pp*-win_amd64 pp*-win32"
-          CIBW_PRERELEASE_PYTHONS: "True" # XXX Can be removed on cibuildwheel 2.20
         run: |
           MATRIX=$(
             {
@@ -146,7 +145,7 @@ jobs:
 
     - name: Build wheels
       if: steps.should-build-wheel.outputs.true
-      uses: pypa/cibuildwheel@v2.19.2
+      uses: pypa/cibuildwheel@v2.20.0
       with:
         only: ${{ matrix.cibw-only }}
       env:
@@ -173,18 +172,18 @@ jobs:
 
     - name: Print build identifiers
       run: |
-        python -m pip install cibuildwheel==2.19.2
+        python -m pip install cibuildwheel==2.20.0
         CIBW_SKIP=cp38-macosx_arm64 python -m cibuildwheel --print-build-identifiers
 
     - name: Build wheels
       if: ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) }}
-      uses: pypa/cibuildwheel@v2.19.2
+      uses: pypa/cibuildwheel@v2.20.0
       env:
         CIBW_SKIP: cp38-macosx_arm64
 
     - name: Build wheels
       if: ${{ !(github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')) }}
-      uses: pypa/cibuildwheel@v2.19.2
+      uses: pypa/cibuildwheel@v2.20.0
       with:
         only: cp310-macosx_arm64
 

--- a/makefile
+++ b/makefile
@@ -28,5 +28,5 @@ _virtualenv:
 	_virtualenv/bin/pip install --upgrade wheel
 
 jq.c: _virtualenv jq.pyx
-	_virtualenv/bin/pip install cython==0.29.35
+	_virtualenv/bin/pip install cython
 	_virtualenv/bin/cython jq.pyx

--- a/makefile
+++ b/makefile
@@ -28,5 +28,5 @@ _virtualenv:
 	_virtualenv/bin/pip install --upgrade wheel
 
 jq.c: _virtualenv jq.pyx
-	_virtualenv/bin/pip install cython
+	_virtualenv/bin/pip install cython==3.0.10
 	_virtualenv/bin/cython jq.pyx

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,8 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Programming Language :: Python :: Implementation :: CPython',
     ],
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311,py312,pypy3
+envlist = py36,py37,py38,py39,py310,py311,py312,py313,pypy3
 isolated_build = True
 [testenv]
 changedir = {envtmpdir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311,py312,py313,pypy3
+envlist = py36,py37,py38,py39,py310,py311,py312,py313,pypy37,pypy38,pypy39,pypy310
 isolated_build = True
 [testenv]
 changedir = {envtmpdir}


### PR DESCRIPTION
Hello! Small MR to add Python 3.13 support and wheels, so downstream projects can already start testing and building against 3.13.

Thanks for these bindings, and have a great day!

## Changes

- Update cibuildwheel to [v2.20.0](https://github.com/pypa/cibuildwheel/releases/tag/v2.20.0)
  - "CPython 3.13 wheels are now built by default - without the CIBW_PRERELEASE_PYTHONS flag. It's time to build and upload these wheels to PyPI! This release includes CPython 3.13.0rc1, which is guaranteed to be ABI compatible with the final release. Free-threading is still behind a flag/config option."
- Update cython to 3.0.10, with Python 3.13 support
  - [Migration guide](https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html) for reference   - 3.1 will remove Python 2.7 - 3.6 support
- Test against all Pypy versions we build wheels for
- Classifiers update