### PR TITLE
Add input_file() to stream input from a file object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,16 @@ Call ``.input_values()`` to supply multiple valid JSON values, such as the value
 
     assert jq.compile(".+5").input_values([1, 2, 3]).all() == [6, 7, 8]
 
+Call ``.input_file()`` to supply a file object in text mode:
+
+.. code-block:: python
+
+    import io
+    import jq
+
+    assert jq.compile(".").input_file(io.StringIO("42")).first() == 42
+    assert jq.compile(".").input_file(io.StringIO("1\n2\n3")).all() == [1, 2, 3]
+
 Call ``.input_text()`` to supply unparsed JSON text:
 
 .. code-block:: python


### PR DESCRIPTION
I would love to use jq for streaming JSON input instead of using e.g. ijson, but the current jq.py interface only supports providing the entire input in one go.

Instead of calling jv_parser_set_buf once in `__cinit__`, call it several times like in jv_file.c.

Since the utf8 backtracking code in jv_unicode.h is not shipped with jq, the interface only supports text-mode files, such that Python ensures that we do not pass data with split utf8 codepoints to jq.