### PR TITLE
Fix syntax error messages format in tests for libjq 1.9.0

### DIFF
--- a/tests/jq_old_tests.py
+++ b/tests/jq_old_tests.py
@@ -79,6 +79,8 @@ def test_value_error_is_raised_if_program_is_invalid():
             "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
             # jq 1.7
             "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting end of file (Unix shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
+            # jq 1.9
+            "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting end of file at <top-level>, line 1, column 1:\n    !\n    ^\njq: 1 compile error",
             # jq 1.6 -win
             "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Windows cmd shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
             # jq 1.7 -win

--- a/tests/jq_tests.py
+++ b/tests/jq_tests.py
@@ -199,6 +199,8 @@ def test_value_error_is_raised_if_program_is_invalid():
             "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
             # jq 1.7
             "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting end of file (Unix shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
+            # jq 1.9
+            "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting end of file at <top-level>, line 1, column 1:\n    !\n    ^\njq: 1 compile error",
             # jq 1.6 -win
             "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Windows cmd shell quoting issues?) at <top-level>, line 1:\n!\njq: 1 compile error",
             # jq 1.7 -win


### PR DESCRIPTION
Change format of syntax errors in tests according to new jq one. See: https://github.com/jqlang/jq/commit/b733dfaee788542daa20bd15d7711d3da3216cc8