### PR TITLE
Update to jq 1.8.2

### DIFF
--- a/tests/jq_old_tests.py
+++ b/tests/jq_old_tests.py
@@ -95,8 +95,7 @@ def test_value_error_is_raised_if_input_cannot_be_processed_by_program():
         program.transform(1)
         assert False, "Expected error"
     except ValueError as error:
-        expected_error_str = "Cannot index number with string \"x\""
-        assert_equal(str(error), expected_error_str)
+        assert "Cannot index number with string" in str(error)
 
 
 def test_errors_do_not_leak_between_transformations():

--- a/tests/jq_tests.py
+++ b/tests/jq_tests.py
@@ -215,8 +215,7 @@ def test_value_error_is_raised_if_input_cannot_be_processed_by_program():
         program.input(1).all()
         assert False, "Expected error"
     except ValueError as error:
-        expected_error_str = "Cannot index number with string \"x\""
-        assert_equal(str(error), expected_error_str)
+        assert "Cannot index number with string" in str(error)
 
 
 def test_non_string_error_is_converted_to_json_text():


### PR DESCRIPTION
jq changed its behaviour here: https://github.com/jqlang/jq/pull/3478

tests in Debian are also failing: https://bugs.debian.org/1141009

Relaxed the test from assert equal to substring match, allowing the tests work for both 1.8.1 and 1.8.2.